### PR TITLE
Push the built output to its own branch so that we can use that inste…

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,19 @@
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: NullVoxPopuli/action-setup-pnpm@v2.0.0
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…ad of build locally.

(see slack for additional context)

This is the same technique used in ember-resources here: https://github.com/NullVoxPopuli/ember-resources/blob/main/.github/workflows/push-dist.yml

And here is what the branch looks like: https://github.com/NullVoxPopuli/ember-resources/tree/dist
(basically what is expected in the npm package)